### PR TITLE
Fixed setting menu Views selectable

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -583,3 +583,11 @@ msgstr ""
 msgctxt "#30141"
 msgid "Disable startup notification"
 msgstr ""
+
+msgctxt "#30142"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30143"
+msgid "Custom view ID"
+msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -583,3 +583,11 @@ msgstr "Migra la libreria nel nuovo formato"
 msgctxt "#30141"
 msgid "Disable startup notification"
 msgstr "Disabilita notifica all'avvio"
+
+msgctxt "#30142"
+msgid "Custom"
+msgstr "Personalizzata"
+
+msgctxt "#30143"
+msgid "Custom view ID"
+msgstr "ID Vista personalizzata"

--- a/resources/lib/kodi/listings.py
+++ b/resources/lib/kodi/listings.py
@@ -73,8 +73,16 @@ def _activate_view(view):
     if (('plugin://{}'.format(g.ADDON_ID) in
          xbmc.getInfoLabel('Container.FolderPath')) and
             g.ADDON.getSettingBool('customview')):
-        view_id = g.ADDON.getSettingInt('viewmode' + view)
-        if view_id != -1:
+
+        #enum order: List|Poster|IconWall|Shift|InfoWall|WideList|Wall|Banner|FanArt|Custom
+        views_id_list = [50, 51, 52, 53, 54, 55, 500, 501, 502, -1]
+
+        view_id = views_id_list[int(g.ADDON.getSettingInt('viewmode' + view))]
+
+        if view_id == -1:
+            view_id = int(g.ADDON.getSettingInt('viewmode' + view + 'id'))
+
+        if view_id != -1 and view_id != 0:
             xbmc.executebuiltin(
                 'Container.SetViewMode({})'.format(view_id))
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -32,13 +32,20 @@
   </category>
   <category label="30037">
     <setting id="customview" type="bool" label="30038" default="false"/>
-    <setting id="viewmodelogin" type="number" label="30044" enable="eq(-1,true)" default="501" visible="false"/>
-    <setting id="viewmodefolder" type="number" label="30039" enable="eq(-2,true)" default="501"/>
-    <setting id="viewmodemovie" type="number" label="30040" enable="eq(-3,true)" default="504"/>
-    <setting id="viewmodeshow" type="number" label="30041" enable="eq(-4,true)" default="504"/>
-    <setting id="viewmodeseason" type="number" label="30042" enable="eq(-5,true)" default="504"/>
-    <setting id="viewmodeepisode" type="number" label="30043" enable="eq(-6,true)" default="55"/>
-    <setting id="viewmodeexported" type="number" label="30074" enable="eq(-7,true)" default="504"/>
+    <setting id="viewmodelogin" type="select" label="30044" lvalues="535|20021|31099|31100|31101|31107|31102|20020|20445|30142" default="7" enable="eq(-1,true)" visible="false"/>
+    <setting id="viewmodeloginid" type="number" label="30143" visible="eq(-1,9) + eq(-2,true)" enable="eq(-2,true)" subsetting="true"/>
+    <setting id="viewmodefolder" type="select" label="30039" lvalues="535|20021|31099|31100|31101|31107|31102|20020|20445|30142" default="7" enable="eq(-3,true)"/>
+    <setting id="viewmodefolderid" type="number" label="30143" visible="eq(-1,9) + eq(-4,true)" enable="eq(-4,true)" subsetting="true"/>
+    <setting id="viewmodemovie" type="select" label="30040" lvalues="535|20021|31099|31100|31101|31107|31102|20020|20445|30142" default="8" enable="eq(-5,true)"/>
+    <setting id="viewmodemovieid" type="number" label="30143" visible="eq(-1,9) + eq(-6,true)" enable="eq(-6,true)" subsetting="true"/>
+    <setting id="viewmodeshow" type="select" label="30041" lvalues="535|20021|31099|31100|31101|31107|31102|20020|20445|30142" default="8" enable="eq(-7,true)"/>
+    <setting id="viewmodeshowid" type="number" label="30143" visible="eq(-1,9) + eq(-8,true)" enable="eq(-8,true)" subsetting="true"/>
+    <setting id="viewmodeseason" type="select" label="30042" lvalues="535|20021|31099|31100|31101|31107|31102|20020|20445|30142" default="8" enable="eq(-9,true)"/>
+    <setting id="viewmodeseasonid" type="number" label="30143" visible="eq(-1,9) + eq(-10,true)" enable="eq(-10,true)" subsetting="true"/>
+    <setting id="viewmodeepisode" type="select" label="30043" lvalues="535|20021|31099|31100|31101|31107|31102|20020|20445|30142" default="5" enable="eq(-11,true)"/>
+    <setting id="viewmodeepisodeid" type="number" label="30143" visible="eq(-1,9) + eq(-12,true)" enable="eq(-12,true)" subsetting="true"/>
+    <setting id="viewmodeexported" type="select" label="30074" lvalues="535|20021|31099|31100|31101|31107|31102|20020|20445|30142" default="8" enable="eq(-13,true)"/>
+    <setting id="viewmodeexportedid" type="number" label="30143" visible="eq(-1,9) + eq(-14,true)" enable="eq(-14,true)" subsetting="true"/>
   </category>
   <category label="30078">
     <setting id="BookmarkManager_enabled" type="bool" label="30083" visible="false" default="true"/>


### PR DESCRIPTION
The views can now be selected via a user-friendly menu,
-the translations are picked directly from kodi resource,
-the immission of the custom id is allowed only through the selectio of item 'custom'

Problems:
Not all View settings works (ex. Movies), need more fixes behind the code,
I have not yet studied well the functioning of the situation seems to lack distinction between the various menus

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?
